### PR TITLE
1.0.2 & 1.0.3

### DIFF
--- a/site-functionality.php
+++ b/site-functionality.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Site Functionality
  * Plugin URI:        https://github.com/misfist/rkc-plugin/
  * Description:       Custom WordPress functionality.
- * Version:           1.0.1
+ * Version:           1.0.2
  * Requires PHP:      7.4
  * Author:            Pea
  * Author URI:        https://pealutz.me

--- a/site-functionality.php
+++ b/site-functionality.php
@@ -15,7 +15,7 @@
  * Plugin Name:       Site Functionality
  * Plugin URI:        https://github.com/misfist/rkc-plugin/
  * Description:       Custom WordPress functionality.
- * Version:           1.0.2
+ * Version:           1.0.3
  * Requires PHP:      7.4
  * Author:            Pea
  * Author URI:        https://pealutz.me
@@ -46,7 +46,7 @@ require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'SITE_FUNCTIONALITY_VERSION', '1.0.1' );
+define( 'SITE_FUNCTIONALITY_VERSION', '1.0.3' );
 define( 'SITE_FUNCTIONALITY_BASENAME', plugin_basename( __FILE__ ) );
 define( 'SITE_FUNCTIONALITY_PATH', plugin_dir_path( __FILE__ ) );
 define( 'SITE_FUNCTIONALITY_URL', trailingslashit( plugins_url( plugin_basename( __DIR__ ) ) ) );

--- a/src/app/integrations/class-paid-memberships-pro.php
+++ b/src/app/integrations/class-paid-memberships-pro.php
@@ -81,10 +81,12 @@ class Paid_Memberships_Pro extends Base {
 
 		/**
 		 * Addon Packages Post Types
+		 * 
+		 * @since 1.0.2
 		 *
 		 * @link https://www.paidmembershipspro.com/add-ons/pmpro-purchase-access-to-a-single-page/
 		 */
-		\add_filter( 'pmproap_supported_post_types', $this->data['post_types'] );
+		\add_filter( 'pmproap_supported_post_types', array( $this, 'addon_package_post_types' ) );
 
 		/**
 		 * @see https://www.paidmembershipspro.com/assign-a-membership-level-to-a-wordpress-user-role/
@@ -227,6 +229,21 @@ class Paid_Memberships_Pro extends Base {
 		}
 
 		return $has_access;
+	}
+
+	/**
+	 * Enable Addon Package for All Post Types
+	 * 
+	 * @link https://www.paidmembershipspro.com/add-ons/pmpro-purchase-access-to-a-single-page/
+	 * 
+	 * @since 1.0.2
+	 *
+	 * @param array $post_types
+	 * @return array
+	 */
+	public function addon_package_post_types( array $post_types ) : array {
+		$post_types = $this->data['post_types'];
+		return $post_types;
 	}
 
 	/**

--- a/src/app/integrations/class-paid-memberships-pro.php
+++ b/src/app/integrations/class-paid-memberships-pro.php
@@ -84,7 +84,7 @@ class Paid_Memberships_Pro extends Base {
 		 *
 		 * @link https://www.paidmembershipspro.com/add-ons/pmpro-purchase-access-to-a-single-page/
 		 */
-		// \add_filter( 'pmproap_supported_post_types', $this->data['post_types'] );
+		\add_filter( 'pmproap_supported_post_types', $this->data['post_types'] );
 
 		/**
 		 * @see https://www.paidmembershipspro.com/assign-a-membership-level-to-a-wordpress-user-role/


### PR DESCRIPTION
- Enable all post types for Add-on Package plugin
- [Modify checkout page link](https://github.com/misfist/rkc-plugin/commit/b76a769d4922a94f03a5a67c04f14ec2dcdcf752)
   - Append MailChimp lists to URL so they'll be selected by default on the checkout page